### PR TITLE
Pin wpilib-controller version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyfrc ~= 2019.0.7
 robotpy-ctre ~= 2019.2
 robotpy-navx ~= 2019.0
 robotpy-rev ~= 2019.0
-wpilib-controller
+wpilib-controller == 0.4.1
 numpy ~= 1.15
 dataclasses; python_version < '3.7'
 


### PR DESCRIPTION
I just updated the wpilib-controller package with changes from the
upstream PR.  We should update our code to use this at some point.

Any subsequent builds will fail if either this isn't merged in,
or someone actually updates the code to use the new calculate method.