### PR TITLE
chassis: Use pinv instead of solving least squares

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyfrc ~= 2019.0.7
 robotpy-ctre ~= 2019.2
 robotpy-navx ~= 2019.0
 robotpy-rev ~= 2019.0
-wpilib-controller
+wpilib-controller == 0.4.1
 numpy ~= 1.15
 dataclasses; python_version < '3.7'
 


### PR DESCRIPTION
Given:

```
v_wheels = [v_1x v_1y v_2x v_2y v_3x v_3y v_4x v_4y].T
v_robot = [v_x v_y w].T
    [1 0 -r_1y]
    [0 1  r_1x]
    [1 0 -r_2y]
A = [0 1  r_2x]
    [1 0 -r_3y]
    [0 1  r_3x]
    [1 0 -r_4y]
    [0 1  r_4x]

v_wheels = A v_robot
```
where:
- **v**_*n* denotes the Cartesian velocity of module _n_, and
- **r**_*n* denotes the Cartesian centre of rotation of module _n_,

we can left-multiply the pseudo-inverse of A to solve for **v**_robot.

I presume this should be significantly faster than solving least squares on the fly.

This is currently on top of #75 (otherwise the tests will fail).